### PR TITLE
Fix: Display Individual Descriptors When CalcMolDescriptors Is Selected

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -130,7 +130,7 @@ def get_all_descriptors():
         'qed': {name: func for name, func in inspect.getmembers(QED, inspect.isfunction) if filter_method(name)},
         'rdfreesasa': {name: func for name, func in inspect.getmembers(rdFreeSASA, inspect.isfunction) if filter_method(name)},
         'descriptor3d': {name: func for name, func in inspect.getmembers(Descriptors3D, inspect.isfunction) if filter_method(name)},
-        'rdmoldescriptors': {name: func for name, func in inspect.getmembers(rdMolDescriptors, callable) if filter_method(name)}
+        'rdmoldescriptors': {name: func for name, func in inspect.getmembers(rdMolDescriptors, callable) if filter_method(name) and name != 'CalcMolDescriptors'}
     }
 
     # Manually added methods
@@ -161,6 +161,13 @@ def compute_descriptors(smiles, selected_options):
 
     if molecule is not None:
         descriptors['SMILES'] = smiles
+
+        if 'CalcMolDescriptors' in selected_options:
+            full_descriptors = Descriptors.CalcMolDescriptors(molecule)
+            for key, value in full_descriptors.items():
+                descriptors[key] = value
+            selected_options = [opt for opt in selected_options if opt != 'CalcMolDescriptors']
+        
         for option in selected_options:
             method_name = option
             if method_name in all_descriptors['chem']:

--- a/app/app.py
+++ b/app/app.py
@@ -130,7 +130,7 @@ def get_all_descriptors():
         'qed': {name: func for name, func in inspect.getmembers(QED, inspect.isfunction) if filter_method(name)},
         'rdfreesasa': {name: func for name, func in inspect.getmembers(rdFreeSASA, inspect.isfunction) if filter_method(name)},
         'descriptor3d': {name: func for name, func in inspect.getmembers(Descriptors3D, inspect.isfunction) if filter_method(name)},
-        'rdmoldescriptors': {name: func for name, func in inspect.getmembers(rdMolDescriptors, callable) if filter_method(name) and name != 'CalcMolDescriptors'}
+        'rdmoldescriptors': {name: func for name, func in inspect.getmembers(rdMolDescriptors, callable) if filter_method(name) and (name != 'CalcMolDescriptors') or (name != 'CalcMolDescriptors3D')}
     }
 
     # Manually added methods
@@ -167,6 +167,13 @@ def compute_descriptors(smiles, selected_options):
             for key, value in full_descriptors.items():
                 descriptors[key] = value
             selected_options = [opt for opt in selected_options if opt != 'CalcMolDescriptors']
+        if 'CalcMolDescriptors3D' in selected_options:
+            if molecule.GetNumConformers() == 0:
+                AllChem.EmbedMolecule(molecule, AllChem.ETKDG())
+            full_descriptors = Descriptors3D.CalcMolDescriptors3D(molecule)
+            for key, value in full_descriptors.items():
+                descriptors[key] = value
+            selected_options = [opt for opt in selected_options if opt != 'CalcMolDescriptors3D']
         
         for option in selected_options:
             method_name = option

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+blinker==1.8.2
+click==8.1.7
+Flask==3.0.3
+itsdangerous==2.2.0
+Jinja2==3.1.4
+MarkupSafe==3.0.2
+numpy==2.1.2
+pillow==11.0.0
+rdkit==2024.3.5
+Werkzeug==3.0.4


### PR DESCRIPTION
Selecting CalcMolDescriptors automatically checks and displays each individual descriptor separately. Closes #6 

<img width="768" alt="bilde" src="https://github.com/user-attachments/assets/f32873d6-a94f-49f6-99da-868862305d34">
